### PR TITLE
cleanup during install step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:wheezy
 MAINTAINER Anastas Dancha <anapsix@random.io>
 
 RUN apt-get update
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes libxml2-dev libxslt-dev libreadline6-dev libc6-dev libssl-dev libyaml-dev libicu-dev zlib1g-dev libsqlite3-dev libmysqlclient-dev wget gcc build-essential make git sudo postfix cron ruby1.9.1 ruby1.9.1-dev rubygems-integration redis-server
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes libxml2-dev libxslt-dev libreadline6-dev libc6-dev libssl-dev libyaml-dev libicu-dev zlib1g-dev libsqlite3-dev libmysqlclient-dev wget gcc build-essential make git sudo postfix cron ruby1.9.1 ruby1.9.1-dev rubygems-integration redis-server && apt-get clean all
 RUN gem install bundle --no-ri --no-rdoc
 
 RUN adduser --disabled-login --gecos 'GitLab CI' gitlab_ci
@@ -29,7 +29,6 @@ RUN cd /home/gitlab_ci/gitlab-ci; sudo -u gitlab_ci -H bundle exec whenever -w R
 RUN chown gitlab_ci -R /home/gitlab_ci
 
 # cleanup, if needed
-RUN DEBIAN_FRONTEND=noninteractive apt-get clean all
 #RUN DEBIAN_FRONTEND=noninteractive apt-get remove --force-yes -y ruby1.9.1-dev
 #RUN DEBIAN_FRONTEND=noninteractive apt-get autoremove --force-yes -y
 


### PR DESCRIPTION
Deleting apt cache in each RUN step is history and file-size friendly.
